### PR TITLE
feat: recreate home page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ function App() {
         className="hero"
         style={{
           backgroundImage:
-            "url('http://static1.squarespace.com/static/58fb0b1d414fb5f44892da9e/t/5ea688ff41e9232ab09e7b07/1584798644478/Merel+Schoneveld-10.jpg')",
+            "url('https://static1.squarespace.com/static/58fb0b1d414fb5f44892da9e/t/5ea688ff41e9232ab09e7b07/1584798644478/Merel+Schoneveld-10.jpg')",
         }}
       >
         <div className="overlay">


### PR DESCRIPTION
## Summary
- Replace placeholder React app with a recreation of Merel Schoneveld's homepage
- Add simple navigation, hero, and gallery sections styled with basic CSS
- Remove obsolete docs directory and update project documentation and page title
- Switch hero section background to HTTPS to avoid mixed-content blocking

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0e0747f8c8330962c42b66bf7ead6